### PR TITLE
Inlined all functions and removed constructors/destructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-### LiteChaCha is a basic, readable implementation of a cipher suite written for Arduino. It uses X25519 to perform ecdhe, Ed25519 for digital signatures, ChaCha20 for bulk encryption and decryption, and Poly1305 for message authentication.
+### LiteChaCha is a basic, readable, header-only implementation of a cipher suite written for Arduino. It uses X25519 to perform ecdhe, Ed25519 for digital signatures, ChaCha20 for bulk encryption and decryption, and Poly1305 for message authentication.
 
 ---
 
@@ -14,7 +14,7 @@
 
   * Lite ChaCha is not guaranteed to be performant, and is very likely susceptible to side-channel attacks. It is also not guaranteed to be updated. Frankly, it was made for fun, so **USE AT YOUR OWN PERIL**!
 
-  * LiteChaCha was made to be run on the Arduino Nano 33 IoT. It may work on other microcontrollers, but it should be noted that the Arduino Nano 33 IoT uses a 32-Bit processor. Microcontrollers that are unable to handle at least 32 Bits are very likely to run far less efficiently due to the fact that LiteChaCha primarily handles data in 32 Bit words.
+  * LiteChaCha was made to be run on the Arduino Nano 33 IoT. It may work on other microcontrollers, but has not been validated to run on anything else. LiteChaCha is not guaranteed to run on anything other than the Arduino Nano 33 IoT.
 
   * LiteChaCha is in the public domain for all to use freely.
 

--- a/src/include/Ed25519.h
+++ b/src/include/Ed25519.h
@@ -114,9 +114,6 @@ private:
 
 	bool decodePoint(uint32_t*, uint32_t*, uint32_t*, uint32_t*, char*);
 public:
-	Ed25519SignatureAlgorithm();
-	~Ed25519SignatureAlgorithm();
-
 	void initialize(char[KEY_BYTES], char[KEY_BYTES]);
 
 	void sign(char[SIGNATURE_BYTES], char[KEY_BYTES], char[KEY_BYTES], char*, bool, unsigned long long);
@@ -124,17 +121,7 @@ public:
 };
 
 
-Ed25519SignatureAlgorithm::Ed25519SignatureAlgorithm() {
-
-}
-
-
-Ed25519SignatureAlgorithm::~Ed25519SignatureAlgorithm() {
-
-}
-
-
-void Ed25519SignatureAlgorithm::generateReadAndPruneHash(char* privateKey) {
+inline void Ed25519SignatureAlgorithm::generateReadAndPruneHash(char* privateKey) {
 	hash.hashBytes(hashBuffer, privateKey, KEY_BYTES);
 
 	for(unsigned short i = 0; i < KEY_BYTES; i += 1) {
@@ -155,7 +142,7 @@ void Ed25519SignatureAlgorithm::generateReadAndPruneHash(char* privateKey) {
 }
 
 
-void Ed25519SignatureAlgorithm::ladderAdd(uint32_t* outX, uint32_t* outY, uint32_t* outZ, uint32_t* outT) {
+inline void Ed25519SignatureAlgorithm::ladderAdd(uint32_t* outX, uint32_t* outY, uint32_t* outZ, uint32_t* outT) {
 	math.base16Sub(regA, ptQ.Y, ptQ.X);
 	math.base16Sub(regB, ptP.Y, ptP.X);
 	math.base16Mul(regA, regA, regB);
@@ -177,7 +164,7 @@ void Ed25519SignatureAlgorithm::ladderAdd(uint32_t* outX, uint32_t* outY, uint32
 }
 
 
-void Ed25519SignatureAlgorithm::ladderDouble() {
+inline void Ed25519SignatureAlgorithm::ladderDouble() {
 	math.base16Mul(regA, ptP.X, ptP.X);
 	math.base16Mul(regB, ptP.Y, ptP.Y);
 	math.base16Mul(regC, ptP.Z, ptP.Z);
@@ -195,7 +182,7 @@ void Ed25519SignatureAlgorithm::ladderDouble() {
 }
 
 
-void Ed25519SignatureAlgorithm::Ed25519(const uint32_t* PX, const uint32_t* PY, const uint32_t* PZ, const uint32_t* PT) {
+inline void Ed25519SignatureAlgorithm::Ed25519(const uint32_t* PX, const uint32_t* PY, const uint32_t* PZ, const uint32_t* PT) {
 	for(unsigned short i = 0; i < INT_LENGTH_MULTI; i += 1) {
 		ptP.X[i] = PX[i];
 		ptP.Y[i] = PY[i];
@@ -223,7 +210,7 @@ void Ed25519SignatureAlgorithm::Ed25519(const uint32_t* PX, const uint32_t* PY, 
 }
 
 
-void Ed25519SignatureAlgorithm::commonInverse() {
+inline void Ed25519SignatureAlgorithm::commonInverse() {
 	math.base16Mul(regA, ptQ.Z, ptQ.Z);
 	math.base16Mul(regB, regA, regA);
 	math.base16Mul(regC, regB, regB);
@@ -292,7 +279,7 @@ void Ed25519SignatureAlgorithm::commonInverse() {
 }
 
 
-void Ed25519SignatureAlgorithm::inverse() { // Copied directly from Daniel J. Bernstein.
+inline void Ed25519SignatureAlgorithm::inverse() { // Copied directly from Daniel J. Bernstein.
 	commonInverse();
 
 	math.base16Mul(regB, regC, regC);
@@ -302,7 +289,7 @@ void Ed25519SignatureAlgorithm::inverse() { // Copied directly from Daniel J. Be
 }
 
 
-void Ed25519SignatureAlgorithm::encodePoint() {
+inline void Ed25519SignatureAlgorithm::encodePoint() {
 	for(unsigned short i = 0; i < INT_LENGTH_MULTI; i += 1) {
 		encodeBytes[(i*2)] = inverseY[(INT_LENGTH_MULTI - 1) - i];
 		encodeBytes[(i*2) + 1] = inverseY[(INT_LENGTH_MULTI - 1) - i] >> 8;
@@ -312,7 +299,7 @@ void Ed25519SignatureAlgorithm::encodePoint() {
 }
 
 
-void Ed25519SignatureAlgorithm::hashModOrder(uint32_t* intOut, char* message, unsigned long long messageBytes) {
+inline void Ed25519SignatureAlgorithm::hashModOrder(uint32_t* intOut, char* message, unsigned long long messageBytes) {
 	hash.hashBytes(hashBuffer, message, messageBytes);
 
 	for(unsigned short i = 0; i < (2*INT_LENGTH_MULTI); i += 1) {
@@ -324,7 +311,7 @@ void Ed25519SignatureAlgorithm::hashModOrder(uint32_t* intOut, char* message, un
 }
 
 
-bool Ed25519SignatureAlgorithm::greaterThanOrEqualToP(uint32_t* a) {
+inline bool Ed25519SignatureAlgorithm::greaterThanOrEqualToP(uint32_t* a) {
 	for(unsigned short i = 0; i < INT_LENGTH_MULTI; i += 1) {
 		if(a[i] > p[i]) {
 			return true;
@@ -338,7 +325,7 @@ bool Ed25519SignatureAlgorithm::greaterThanOrEqualToP(uint32_t* a) {
 }
 
 
-bool Ed25519SignatureAlgorithm::equalToZero(uint32_t* a) {
+inline bool Ed25519SignatureAlgorithm::equalToZero(uint32_t* a) {
 	for(unsigned short i = 0; i < INT_LENGTH_MULTI; i += 1) {
 		if(a[i] != 0x00000000) {
 			return false;
@@ -349,14 +336,14 @@ bool Ed25519SignatureAlgorithm::equalToZero(uint32_t* a) {
 }
 
 
-void Ed25519SignatureAlgorithm::p38p() { // Adapted from Daniel J. Bernstein. Calculates ptQ.X = (ptQ.Z)^((p+3)/8) % p.
+inline void Ed25519SignatureAlgorithm::p38p() { // Adapted from Daniel J. Bernstein. Calculates ptQ.X = (ptQ.Z)^((p+3)/8) % p.
 	commonInverse();
 
 	math.base16Mul(ptQ.X, regC, regA);
 }
 
 
-bool Ed25519SignatureAlgorithm::recoverXCoord() {
+inline bool Ed25519SignatureAlgorithm::recoverXCoord() {
 	if(greaterThanOrEqualToP(ptQ.Y)) {
 		return false;
 	}
@@ -402,7 +389,7 @@ bool Ed25519SignatureAlgorithm::recoverXCoord() {
 }
 
 
-bool Ed25519SignatureAlgorithm::decodePoint(uint32_t* pointOutX, uint32_t* pointOutY, uint32_t* pointOutZ, uint32_t* pointOutT, char* encodedPoint) {
+inline bool Ed25519SignatureAlgorithm::decodePoint(uint32_t* pointOutX, uint32_t* pointOutY, uint32_t* pointOutZ, uint32_t* pointOutT, char* encodedPoint) {
 	for(unsigned short i = 0; i < INT_LENGTH_MULTI; i += 1) {
 		ptQ.Y[i] = encodedPoint[31 - (i*2)] << 8; // 31 = KEY_BYTES - 1, or (SIGNATURE_BYTES/2) - 1.
 		ptQ.Y[i] |= encodedPoint[31 - ((i*2) + 1)];
@@ -426,7 +413,7 @@ bool Ed25519SignatureAlgorithm::decodePoint(uint32_t* pointOutX, uint32_t* point
 }
 
 
-bool Ed25519SignatureAlgorithm::greaterThanOrEqualToOrder(uint32_t* a) {
+inline bool Ed25519SignatureAlgorithm::greaterThanOrEqualToOrder(uint32_t* a) {
 	for(unsigned short i = 0; i < INT_LENGTH_MULTI; i += 1) {
 		if(a[i] > L[i]) {
 			return true;
@@ -440,7 +427,7 @@ bool Ed25519SignatureAlgorithm::greaterThanOrEqualToOrder(uint32_t* a) {
 }
 
 
-void Ed25519SignatureAlgorithm::quickEd25519(const uint32_t* PX, const uint32_t* PY, const uint32_t* PZ, const uint32_t* PT) { // A variable-time implementation of Ed25519 for signature verification.
+inline void Ed25519SignatureAlgorithm::quickEd25519(const uint32_t* PX, const uint32_t* PY, const uint32_t* PZ, const uint32_t* PT) { // A variable-time implementation of Ed25519 for signature verification.
 	for(unsigned short i = 0; i < INT_LENGTH_MULTI; i += 1) {
 		ptP.X[i] = PX[i];
 		ptP.Y[i] = PY[i];
@@ -467,7 +454,7 @@ void Ed25519SignatureAlgorithm::quickEd25519(const uint32_t* PX, const uint32_t*
 }
 
 
-void Ed25519SignatureAlgorithm::initialize(char* publicKeyOut, char* privateKey) {
+inline void Ed25519SignatureAlgorithm::initialize(char* publicKeyOut, char* privateKey) {
 	generateReadAndPruneHash(privateKey);
 
 	Ed25519(BaseX, BaseY, oneInt, BaseT);
@@ -485,7 +472,7 @@ void Ed25519SignatureAlgorithm::initialize(char* publicKeyOut, char* privateKey)
 }
 
 
-void Ed25519SignatureAlgorithm::sign(char* signatureOut, char* publicKeyInOut, char* privateKey, char* message, bool createPublicKey, unsigned long long messageBytes = KEY_BYTES) {
+inline void Ed25519SignatureAlgorithm::sign(char* signatureOut, char* publicKeyInOut, char* privateKey, char* message, bool createPublicKey, unsigned long long messageBytes = KEY_BYTES) {
 	if(createPublicKey == true) {
 		initialize(publicKeyInOut, privateKey);
 	} else {
@@ -543,7 +530,7 @@ void Ed25519SignatureAlgorithm::sign(char* signatureOut, char* publicKeyInOut, c
 }
 
 
-bool Ed25519SignatureAlgorithm::verify(char* publicKey, char* message, char* signature, unsigned long long messageBytes = KEY_BYTES) { // Not constant time: all components are public.
+inline bool Ed25519SignatureAlgorithm::verify(char* publicKey, char* message, char* signature, unsigned long long messageBytes = KEY_BYTES) { // Not constant time: all components are public.
 	if(!decodePoint(ptA.X, ptA.Y, ptA.Z, ptA.T, publicKey)) {
 		return false;
 	}

--- a/src/include/SHA512.h
+++ b/src/include/SHA512.h
@@ -70,24 +70,11 @@ private:
 
 	void outputHash(char[HASH_BYTES]);
 public:
-	SHA512Hash();
-	~SHA512Hash();
-
 	void hashBytes(char[HASH_BYTES], char*, unsigned long long);
 };
 
 
-SHA512Hash::SHA512Hash() {
-
-}
-
-
-SHA512Hash::~SHA512Hash() {
-
-}
-
-
-void SHA512Hash::initialize(unsigned long long messageBytes) {
+inline void SHA512Hash::initialize(unsigned long long messageBytes) {
 	for(unsigned short i = 0; i < HASH_WORDS; i += 1) {
 		h[i] = hInit[i];
 	}
@@ -104,7 +91,7 @@ void SHA512Hash::initialize(unsigned long long messageBytes) {
 }
 
 
-void SHA512Hash::buildMessage(uint64_t* message, char* messageIn, unsigned long long messageBytes) {
+inline void SHA512Hash::buildMessage(uint64_t* message, char* messageIn, unsigned long long messageBytes) {
 	for(unsigned long long i = 0; i < messageWords; i += 1) {
 		message[i] = 0x0000000000000000;
 		for(unsigned short j = 0; j < HALF_WORD_CONVERSION; j += 1) {
@@ -160,12 +147,12 @@ void SHA512Hash::buildMessage(uint64_t* message, char* messageIn, unsigned long 
 }
 
 
-void SHA512Hash::rotR(uint64_t n, unsigned short c) {
+inline void SHA512Hash::rotR(uint64_t n, unsigned short c) {
 	wordBuffer = ((n >> c) | (n << (WORD_BITS - c)));
 }
 
 
-void SHA512Hash::hashProcess(uint64_t* message) {
+inline void SHA512Hash::hashProcess(uint64_t* message) {
 	for(unsigned long long b = 0; b < blockCount; b += 1) {
 		for(unsigned short i = 0; i < BLOCK_WORDS; i += 1) {
 			w[i] = message[(BLOCK_WORDS*b) + i];
@@ -230,7 +217,7 @@ void SHA512Hash::hashProcess(uint64_t* message) {
 }
 
 
-void SHA512Hash::outputHash(char* hashOut) {
+inline void SHA512Hash::outputHash(char* hashOut) {
 	for(unsigned short i = 0; i < HASH_WORDS; i += 1) {
 		for(unsigned short j = 0; j < WORD_CONVERSION; j += 1) {
 			hashOut[(WORD_CONVERSION*i) + j] = h[i] >> (WORD_SHIFT - (BIT_CONVERSION*j));
@@ -239,7 +226,7 @@ void SHA512Hash::outputHash(char* hashOut) {
 }
 
 
-void SHA512Hash::hashBytes(char* hashOut, char* messageIn, unsigned long long messageBytes) {
+inline void SHA512Hash::hashBytes(char* hashOut, char* messageIn, unsigned long long messageBytes) {
 	initialize(messageBytes);
 
 	uint64_t* message = new uint64_t[wordIndex + 1];

--- a/src/include/X25519.h
+++ b/src/include/X25519.h
@@ -58,24 +58,11 @@ private:
 	char* encodeXCoord(char*);
 	void checkAllZerosCase(char*);
 public:
-	X25519KeyExchange();
-	~X25519KeyExchange();
-
 	void curve25519(char[BYTE_LENGTH], char[BYTE_LENGTH]);
 };
 
 
-X25519KeyExchange::X25519KeyExchange() {
-
-}
-
-
-X25519KeyExchange::~X25519KeyExchange() {
-
-}
-
-
-char* X25519KeyExchange::decodeBytesLittleEndian(char* b) {
+inline char* X25519KeyExchange::decodeBytesLittleEndian(char* b) {
 	char temp;
 	for(unsigned short i = 0; i < BYTE_LENGTH/2; i += 1) {
 		temp = b[i];
@@ -87,7 +74,7 @@ char* X25519KeyExchange::decodeBytesLittleEndian(char* b) {
 }
 
 
-char* X25519KeyExchange::clampAndDecodeScalar(char* n) {
+inline char* X25519KeyExchange::clampAndDecodeScalar(char* n) {
 	n[0] &= 0xf8;
 	n[31] &= 0x7f;
 	n[31] |= 0x40;
@@ -98,14 +85,14 @@ char* X25519KeyExchange::clampAndDecodeScalar(char* n) {
 }
 
 
-void X25519KeyExchange::toUInt(uint32_t* outInt, char* b) {
+inline void X25519KeyExchange::toUInt(uint32_t* outInt, char* b) {
 	for(unsigned short i = 0; i < INT_LENGTH; i += 1) {
 		outInt[i] = (b[i*4] << 24) | (b[(i*4) + 1] << 16) | (b[(i*4) + 2] << 8) | b[(i*4) + 3];
 	}
 }
 
 
-char* X25519KeyExchange::maskAndDecodeXCoord(char* x) {
+inline char* X25519KeyExchange::maskAndDecodeXCoord(char* x) {
 	x[31] &= 0x7f;
 
 	x = decodeBytesLittleEndian(x);
@@ -114,7 +101,7 @@ char* X25519KeyExchange::maskAndDecodeXCoord(char* x) {
 }
 
 
-void X25519KeyExchange::cSwap(uint32_t s) {
+inline void X25519KeyExchange::cSwap(uint32_t s) {
 	mask = 0x00000000;
 	mask -= s;
 
@@ -132,7 +119,7 @@ void X25519KeyExchange::cSwap(uint32_t s) {
 }
 
 
-void X25519KeyExchange::ladderStep() {
+inline void X25519KeyExchange::ladderStep() {
 	math.base16Add(A, X2, Z2);
 	math.base16Mul(AA, A, A);
 	math.base16Sub(B, X2, Z2);
@@ -154,7 +141,7 @@ void X25519KeyExchange::ladderStep() {
 }
 
 
-void X25519KeyExchange::montgomeryLadder() {
+inline void X25519KeyExchange::montgomeryLadder() {
 	for(unsigned short i = 0; i < INT_LENGTH_MULTI; i += 1) {
 		X1[i] = xIntMulti[i];
 	}
@@ -187,7 +174,7 @@ void X25519KeyExchange::montgomeryLadder() {
 }
 
 
-void X25519KeyExchange::inverse() { // Copied directly from Daniel J. Bernstein.
+inline void X25519KeyExchange::inverse() { // Copied directly from Daniel J. Bernstein.
 	math.base16Mul(A, Z2, Z2);
 	math.base16Mul(Z3, A, A);
 	math.base16Mul(X3, Z3, Z3);
@@ -260,7 +247,7 @@ void X25519KeyExchange::inverse() { // Copied directly from Daniel J. Bernstein.
 }
 
 
-char* X25519KeyExchange::encodeXCoord(char* x) {
+inline char* X25519KeyExchange::encodeXCoord(char* x) {
 	for(unsigned short i = 0; i < INT_LENGTH; i += 1) {
 		x[i*4] = xInt[i] >> 24;
 		x[(i*4) + 1] = xInt[i] >> 16;
@@ -274,7 +261,7 @@ char* X25519KeyExchange::encodeXCoord(char* x) {
 }
 
 
-void X25519KeyExchange::checkAllZerosCase(char* x) {
+inline void X25519KeyExchange::checkAllZerosCase(char* x) {
 	zerosCheck = 0x00;
 
 	for(unsigned short i = 0; i < BYTE_LENGTH; i += 1) {
@@ -288,7 +275,7 @@ void X25519KeyExchange::checkAllZerosCase(char* x) {
 }
 
 
-void X25519KeyExchange::curve25519(char* n, char* xp) { // n is the independent, uniform, random secret key. It is an array of 32 bytes and is used as the scalar for the elliptic curve.
+inline void X25519KeyExchange::curve25519(char* n, char* xp) { // n is the independent, uniform, random secret key. It is an array of 32 bytes and is used as the scalar for the elliptic curve.
 	n = clampAndDecodeScalar(n);
 
 	toUInt(nInt, n);

--- a/src/include/authenticatedencrypt.h
+++ b/src/include/authenticatedencrypt.h
@@ -24,9 +24,6 @@ private:
 
 	void createPolyKey();
 public:
-	CipherManagement();
-	~CipherManagement();
-
 	unsigned short getTagBytes() {return TAG_BYTES;}
 
 	void initialize(char[KEY_BYTES], char[FIXED_NONCE_BYTES], char[FIXED_NONCE_BYTES]);
@@ -37,22 +34,12 @@ public:
 };
 
 
-CipherManagement::CipherManagement() {
-
-}
-
-
-CipherManagement::~CipherManagement() {
-
-}
-
-
-void CipherManagement::initialize(char* sharedPrivateKey, char* userFixedNonce, char* peerFixedNonce) {
+inline void CipherManagement::initialize(char* sharedPrivateKey, char* userFixedNonce, char* peerFixedNonce) {
 	cipher.buildEncryption(sharedPrivateKey, userFixedNonce, peerFixedNonce);
 }
 
 
-void CipherManagement::createPolyKey() {
+inline void CipherManagement::createPolyKey() {
 	for(unsigned short i = 0; i < POLY_KEY_LENGTH; i += 1) {
 		polyKey[i] = polyKeyMaterial[i] << 24;
 		polyKey[i] |= ((polyKeyMaterial[i] & 0x0000ff00) << 8);
@@ -62,7 +49,7 @@ void CipherManagement::createPolyKey() {
 }
 
 
-void CipherManagement::encryptAndTagMessage(unsigned long long& messageCountOut, char* tagOut, char* message, unsigned long long messageBytes) {
+inline void CipherManagement::encryptAndTagMessage(unsigned long long& messageCountOut, char* tagOut, char* message, unsigned long long messageBytes) {
 	if(messageBytes > 0) {
 		polyKeyMaterial = cipher.generateEndState();
 		createPolyKey();
@@ -75,7 +62,7 @@ void CipherManagement::encryptAndTagMessage(unsigned long long& messageCountOut,
 }
 
 
-bool CipherManagement::messageAuthentic(char* message, unsigned long long messageBytes, unsigned long long messageCount, char* tag) {
+inline bool CipherManagement::messageAuthentic(char* message, unsigned long long messageBytes, unsigned long long messageCount, char* tag) {
 	if(messageBytes > 0) {
 		polyKeyMaterial = cipher.generatePeerEndState(messageCount);
 		createPolyKey();
@@ -87,7 +74,7 @@ bool CipherManagement::messageAuthentic(char* message, unsigned long long messag
 }
 
 
-void CipherManagement::decryptAuthenticatedMessage(char* message, unsigned long long messageBytes, unsigned long long messageCount) {
+inline void CipherManagement::decryptAuthenticatedMessage(char* message, unsigned long long messageBytes, unsigned long long messageCount) {
 	if(messageBytes > 0) {
 		cipher.decryptMessage(message, messageBytes, messageCount, INITIAL_BLOCK);
 	}

--- a/src/include/chacha.h
+++ b/src/include/chacha.h
@@ -59,9 +59,6 @@ private:
 	void encryptAndDecryptSubProcess(char*);
 	void encryptAndDecryptProcess(char*);
 public:
-	ChaChaEncryption();
-	~ChaChaEncryption();
-
 	void buildEncryption(char*, char*, char*);
 
 	unsigned long long getNonceCounter() {return (((unsigned long long)nonceCounter[0]) << 32) | nonceCounter[1];}
@@ -74,17 +71,7 @@ public:
 };
 
 
-ChaChaEncryption::ChaChaEncryption() {
-
-}
-
-
-ChaChaEncryption::~ChaChaEncryption() {
-
-}
-
-
-void ChaChaEncryption::buildEncryption(char* userKeyIn, char* userFixedNonceIn, char* peerFixedNonceIn) { // Assumes fixed portion of nonce is 32 bits.
+inline void ChaChaEncryption::buildEncryption(char* userKeyIn, char* userFixedNonceIn, char* peerFixedNonceIn) { // Assumes fixed portion of nonce is 32 bits.
 	for(unsigned short i = 0; i < KEY_LENGTH; i += 1) {
 		key[i] = (userKeyIn[(i*4) + 3] << 24) | (userKeyIn[(i*4) + 2] << 16) | (userKeyIn[(i*4) + 1] << 8) | userKeyIn[i*4];
 	}
@@ -100,7 +87,7 @@ void ChaChaEncryption::buildEncryption(char* userKeyIn, char* userFixedNonceIn, 
 }
 
 
-void ChaChaEncryption::initializeEncryption(unsigned long long bytes, unsigned long startBlock, uint32_t fixedNonce, uint32_t* nonceCounter) { // Not generalized for BLOCK_COUNTER_LENGTH > 1. Assumes fixed portion of nonce is 32 bits.
+inline void ChaChaEncryption::initializeEncryption(unsigned long long bytes, unsigned long startBlock, uint32_t fixedNonce, uint32_t* nonceCounter) { // Not generalized for BLOCK_COUNTER_LENGTH > 1. Assumes fixed portion of nonce is 32 bits.
 	initialBlockCounter = (uint32_t)startBlock;
 	blockCounter = initialBlockCounter;
 
@@ -117,12 +104,12 @@ void ChaChaEncryption::initializeEncryption(unsigned long long bytes, unsigned l
 }
 
 
-uint32_t ChaChaEncryption::rotL(uint32_t n, unsigned short c) {
+inline uint32_t ChaChaEncryption::rotL(uint32_t n, unsigned short c) {
 	return (n << c) | (n >> (32 - c));
 }
 
 
-void ChaChaEncryption::quarterRound(uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d) {
+inline void ChaChaEncryption::quarterRound(uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d) {
 	a += b; d ^= a; d = rotL(d, 16);
 	c += d; b ^= c; b = rotL(b, 12);
 	a += b; d ^= a; d = rotL(d, 8);
@@ -130,7 +117,7 @@ void ChaChaEncryption::quarterRound(uint32_t& a, uint32_t& b, uint32_t& c, uint3
 }
 
 
-void ChaChaEncryption::createEndState() { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
+inline void ChaChaEncryption::createEndState() { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
 	for(unsigned short i = (KEY_LENGTH + CONSTANT_LENGTH); i < (BLOCK_COUNTER_LENGTH + KEY_LENGTH + CONSTANT_LENGTH); i += 1) {
 		startState[i] = blockCounter;
 	}
@@ -157,7 +144,7 @@ void ChaChaEncryption::createEndState() { // Not generalized for BLOCK_COUNTER_L
 }
 
 
-void ChaChaEncryption::createKeyStream() {
+inline void ChaChaEncryption::createKeyStream() {
 	for(unsigned short i = 0; i < BLOCK_LENGTH; i += 1) {
 		keyStream[(i*4)] = endState[i] & BITMASK;
 		keyStream[(i*4) + 1] = (endState[i] >> 8) & BITMASK;
@@ -167,7 +154,7 @@ void ChaChaEncryption::createKeyStream() {
 }
 
 
-void ChaChaEncryption::createCipherText(char* message) { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
+inline void ChaChaEncryption::createCipherText(char* message) { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
 	blockIndexBytes = ((unsigned long)blockCounter - (unsigned long)initialBlockCounter)*BLOCK_BYTES;
 
 	for(unsigned short i = 0; i < encryptBytes; i += 1) {
@@ -176,7 +163,7 @@ void ChaChaEncryption::createCipherText(char* message) { // Not generalized for 
 }
 
 
-void ChaChaEncryption::incrementBlockCounter() { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
+inline void ChaChaEncryption::incrementBlockCounter() { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
 	if(blockCounter == 0xffffffff) {
 		// Log an error here.
 	}
@@ -185,7 +172,7 @@ void ChaChaEncryption::incrementBlockCounter() { // Not generalized for BLOCK_CO
 }
 
 
-void ChaChaEncryption::incrementNonceCounter() { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
+inline void ChaChaEncryption::incrementNonceCounter() { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
 	if(!(nonceCounter[0] == 0xffffffff && nonceCounter[1] == 0xffffffff)) {
 		if(nonceCounter[1] == 0xffffffff) {
 			nonceCounter[1] = 0x00000000;
@@ -200,7 +187,7 @@ void ChaChaEncryption::incrementNonceCounter() { // Not generalized for BLOCK_CO
 }
 
 
-void ChaChaEncryption::incrementPeerNonceCounter() { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
+inline void ChaChaEncryption::incrementPeerNonceCounter() { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
 	if(!(peerNonceCounter[0] == 0xffffffff && peerNonceCounter[1] == 0xffffffff)) {
 		if(peerNonceCounter[1] == 0xffffffff) {
 			peerNonceCounter[1] = 0x00000000;
@@ -215,14 +202,14 @@ void ChaChaEncryption::incrementPeerNonceCounter() { // Not generalized for BLOC
 }
 
 
-void ChaChaEncryption::encryptAndDecryptSubProcess(char* message) {
+inline void ChaChaEncryption::encryptAndDecryptSubProcess(char* message) {
 	createEndState();
 	createKeyStream();
 	createCipherText(message);
 }
 
 
-void ChaChaEncryption::encryptAndDecryptProcess(char* message) {
+inline void ChaChaEncryption::encryptAndDecryptProcess(char* message) {
 	for(unsigned long long i = 0; i < (messageBlockCount - 1); i += 1) {
 		encryptAndDecryptSubProcess(message);
 		incrementBlockCounter();
@@ -236,7 +223,7 @@ void ChaChaEncryption::encryptAndDecryptProcess(char* message) {
 }
 
 
-uint32_t* ChaChaEncryption::generateEndState() {
+inline uint32_t* ChaChaEncryption::generateEndState() {
 	initializeEncryption(EMPTY_BYTES, ZERO_START_BLOCK, fixedNonce, nonceCounter);
 	createEndState();
 
@@ -244,7 +231,7 @@ uint32_t* ChaChaEncryption::generateEndState() {
 }
 
 
-uint32_t* ChaChaEncryption::generatePeerEndState(unsigned long long nonceCounter) {
+inline uint32_t* ChaChaEncryption::generatePeerEndState(unsigned long long nonceCounter) {
 	currentPeerNonceCounter = getPeerNonceCounter();
 	if(nonceCounter != currentPeerNonceCounter) {
 		for(unsigned short i = 0; i < COUNTER_NONCE_LENGTH; i += 1) {
@@ -258,7 +245,7 @@ uint32_t* ChaChaEncryption::generatePeerEndState(unsigned long long nonceCounter
 }
 
 
-void ChaChaEncryption::encryptMessage(char* message, unsigned long long bytes, unsigned long startBlock = 0) {
+inline void ChaChaEncryption::encryptMessage(char* message, unsigned long long bytes, unsigned long startBlock = 0) {
 	if(bytes > 0) {
 		initializeEncryption(bytes, startBlock, fixedNonce, nonceCounter);
 		encryptAndDecryptProcess(message);
@@ -267,7 +254,7 @@ void ChaChaEncryption::encryptMessage(char* message, unsigned long long bytes, u
 }
 
 
-void ChaChaEncryption::decryptMessage(char* message, unsigned long long bytes, unsigned long long nonceCounter, unsigned long startBlock = 0) { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
+inline void ChaChaEncryption::decryptMessage(char* message, unsigned long long bytes, unsigned long long nonceCounter, unsigned long startBlock = 0) { // Not generalized for BLOCK_COUNTER_LENGTH > 1.
 	if(bytes > 0) {
 		currentPeerNonceCounter = getPeerNonceCounter();
 		if(nonceCounter != currentPeerNonceCounter) {

--- a/src/include/keyinfrastructure.h
+++ b/src/include/keyinfrastructure.h
@@ -23,9 +23,6 @@ private:
 
 	char check;
 public:
-	KeyManagement();
-	~KeyManagement();
-
 	unsigned short getKeyBytes() {return KEY_BYTES;}
 	unsigned short getSignatureBytes() {return SIGNATURE_BYTES;}
 	unsigned short getIDBytes() {return ID_BYTES;}
@@ -40,17 +37,7 @@ public:
 };
 
 
-KeyManagement::KeyManagement() {
-
-}
-
-
-KeyManagement::~KeyManagement() {
-
-}
-
-
-void KeyManagement::initialize(char* DSAPrivateKeyInOut, char* DSAPubKeyInOut, char* ephemeralKeyOut, char* signatureOut, char* IDOut, bool generateNewDSAKeys = true) {
+inline void KeyManagement::initialize(char* DSAPrivateKeyInOut, char* DSAPubKeyInOut, char* ephemeralKeyOut, char* signatureOut, char* IDOut, bool generateNewDSAKeys = true) {
 	randnum.generateBytes(IDOut, ID_BYTES);
 	randnum.generateBytes(privateSessionKey, KEY_BYTES);
 
@@ -76,7 +63,7 @@ void KeyManagement::initialize(char* DSAPrivateKeyInOut, char* DSAPubKeyInOut, c
 }
 
 
-bool KeyManagement::IDUnique(char* userID, char* peerID) {
+inline bool KeyManagement::IDUnique(char* userID, char* peerID) {
 	check = 0x00;
 
 	for(unsigned short i = 0; i < ID_BYTES; i += 1) {
@@ -87,12 +74,12 @@ bool KeyManagement::IDUnique(char* userID, char* peerID) {
 }
 
 
-bool KeyManagement::signatureValid(char* DSAPubKey, char* ephemeralPubKey, char* signature) {
+inline bool KeyManagement::signatureValid(char* DSAPubKey, char* ephemeralPubKey, char* signature) {
 	return hancock.verify(DSAPubKey, ephemeralPubKey, signature);
 }
 
 
-void KeyManagement::createSessionKey(char* peerEphemeralPubKey) {
+inline void KeyManagement::createSessionKey(char* peerEphemeralPubKey) {
 	for(unsigned short i = 0; i < KEY_BYTES; i += 1) {
 		curveScalar[i] = privateSessionKey[i];
 	}

--- a/src/include/multiprecision1305.h
+++ b/src/include/multiprecision1305.h
@@ -41,9 +41,6 @@ private:
 	void prepareOut(uint32_t*);
 	void prepareMulOut(uint32_t*); // Used after multiplication and the Barrett reduction.
 public:
-	MultiPrecisionArithmetic1305();
-	~MultiPrecisionArithmetic1305();
-
 	void base32_16(uint32_t*, const uint32_t*);
 
 	void base16Mod(uint32_t*, const uint32_t*);
@@ -52,17 +49,7 @@ public:
 };
 
 
-MultiPrecisionArithmetic1305::MultiPrecisionArithmetic1305() {
-
-}
-
-
-MultiPrecisionArithmetic1305::~MultiPrecisionArithmetic1305() {
-
-}
-
-
-void MultiPrecisionArithmetic1305::base32_16(uint32_t* out, const uint32_t* a) {
+inline void MultiPrecisionArithmetic1305::base32_16(uint32_t* out, const uint32_t* a) {
 	for(unsigned short i = 0; i < (n/2); i += 1) {
 		out[(i*2) + 1] = a[i] >> 16;
 		out[(i*2) + 2] = a[i] & 0x0000ffff;
@@ -72,7 +59,7 @@ void MultiPrecisionArithmetic1305::base32_16(uint32_t* out, const uint32_t* a) {
 }
 
 
-void MultiPrecisionArithmetic1305::prepareModIn(const uint32_t* a) {
+inline void MultiPrecisionArithmetic1305::prepareModIn(const uint32_t* a) {
 	u[1] = 0x00000000;
 
 	for(unsigned short i = 0; i < n; i += 1) {
@@ -81,7 +68,7 @@ void MultiPrecisionArithmetic1305::prepareModIn(const uint32_t* a) {
 }
 
 
-void MultiPrecisionArithmetic1305::base16ModInternal() {
+inline void MultiPrecisionArithmetic1305::base16ModInternal() {
 // ---------- D1 ----------
 	carry = 0x00000000;
 
@@ -167,14 +154,14 @@ void MultiPrecisionArithmetic1305::base16ModInternal() {
 }
 
 
-void MultiPrecisionArithmetic1305::prepareOut(uint32_t* out) {
+inline void MultiPrecisionArithmetic1305::prepareOut(uint32_t* out) {
 	for(unsigned short i = 0; i < n; i += 1) {
 		out[i] = u[i + 2];
 	}
 }
 
 
-void MultiPrecisionArithmetic1305::prepareIn(const uint32_t* a, const uint32_t* b) {
+inline void MultiPrecisionArithmetic1305::prepareIn(const uint32_t* a, const uint32_t* b) {
 	u[1] = 0x00000000;
 	v[0] = 0x00000000;
 
@@ -185,7 +172,7 @@ void MultiPrecisionArithmetic1305::prepareIn(const uint32_t* a, const uint32_t* 
 }
 
 
-void MultiPrecisionArithmetic1305::barrettReduce() {
+inline void MultiPrecisionArithmetic1305::barrettReduce() {
 // ---------- 1 ----------
 	for(unsigned short i = 0; i < (n + 1); i += 1) {
 		v[i] = u[i + 2]; // v is storing q1.
@@ -272,14 +259,14 @@ void MultiPrecisionArithmetic1305::barrettReduce() {
 }
 
 
-void MultiPrecisionArithmetic1305::prepareMulOut(uint32_t* out) {
+inline void MultiPrecisionArithmetic1305::prepareMulOut(uint32_t* out) {
 	for(unsigned short i = 0; i < n; i += 1) {
 		out[i] = u[i + 3];
 	}
 }
 
 
-void MultiPrecisionArithmetic1305::base16Mod(uint32_t* out, const uint32_t* a) {
+inline void MultiPrecisionArithmetic1305::base16Mod(uint32_t* out, const uint32_t* a) {
 	prepareModIn(a);
 
 	m = 1;
@@ -289,7 +276,7 @@ void MultiPrecisionArithmetic1305::base16Mod(uint32_t* out, const uint32_t* a) {
 }
 
 
-void MultiPrecisionArithmetic1305::base16Add(uint32_t* out, const uint32_t* a, const uint32_t* b, bool mod = true) {
+inline void MultiPrecisionArithmetic1305::base16Add(uint32_t* out, const uint32_t* a, const uint32_t* b, bool mod = true) {
 	prepareIn(a, b);
 
 	carry = 0x00000000;
@@ -309,7 +296,7 @@ void MultiPrecisionArithmetic1305::base16Add(uint32_t* out, const uint32_t* a, c
 }
 
 
-void MultiPrecisionArithmetic1305::base16Mul(uint32_t* out, const uint32_t* a, const uint32_t* b, bool barrett) { // Might be able to optimize by using the Karatsuba method, or some other method. Maybe within the modulus operation as well.
+inline void MultiPrecisionArithmetic1305::base16Mul(uint32_t* out, const uint32_t* a, const uint32_t* b, bool barrett) { // Might be able to optimize by using the Karatsuba method, or some other method. Maybe within the modulus operation as well.
 	prepareIn(a, b);
 
 	for(unsigned short i = ((n*2) - 1); i > (n - 1); i -= 1) {

--- a/src/include/multiprecision252ed.h
+++ b/src/include/multiprecision252ed.h
@@ -36,26 +36,13 @@ private:
 
 	void prepareOut(uint32_t*);
 public:
-	MultiPrecisionArithmetic252ed();
-	~MultiPrecisionArithmetic252ed();
-
 	void base16Mod(uint32_t*, const uint32_t*);
 	void base16Add(uint32_t*, const uint32_t*, const uint32_t*);
 	void base16Mul(uint32_t*, const uint32_t*, const uint32_t*);
 };
 
 
-MultiPrecisionArithmetic252ed::MultiPrecisionArithmetic252ed() {
-
-}
-
-
-MultiPrecisionArithmetic252ed::~MultiPrecisionArithmetic252ed() {
-
-}
-
-
-void MultiPrecisionArithmetic252ed::prepareDoubleIn(const uint32_t* a) {
+inline void MultiPrecisionArithmetic252ed::prepareDoubleIn(const uint32_t* a) {
 	u[1] = 0x00000000;
 
 	for(unsigned short i = 0; i < (2*n); i += 1) {
@@ -64,7 +51,7 @@ void MultiPrecisionArithmetic252ed::prepareDoubleIn(const uint32_t* a) {
 }
 
 
-void MultiPrecisionArithmetic252ed::base16ModInternal() {
+inline void MultiPrecisionArithmetic252ed::base16ModInternal() {
 // ---------- D1 ----------
 	carry = 0x00000000;
 
@@ -150,14 +137,14 @@ void MultiPrecisionArithmetic252ed::base16ModInternal() {
 }
 
 
-void MultiPrecisionArithmetic252ed::prepareOut(uint32_t* out) {
+inline void MultiPrecisionArithmetic252ed::prepareOut(uint32_t* out) {
 	for(unsigned short i = 0; i < n; i += 1) {
 		out[i] = u[i + 2];
 	}
 }
 
 
-void MultiPrecisionArithmetic252ed::prepareIn(const uint32_t* a, const uint32_t* b) {
+inline void MultiPrecisionArithmetic252ed::prepareIn(const uint32_t* a, const uint32_t* b) {
 	u[1] = 0x00000000;
 	v[0] = 0x00000000;
 
@@ -168,7 +155,7 @@ void MultiPrecisionArithmetic252ed::prepareIn(const uint32_t* a, const uint32_t*
 }
 
 
-void MultiPrecisionArithmetic252ed::quickAMod() {
+inline void MultiPrecisionArithmetic252ed::quickAMod() {
 	c = 0x00000000;
 	s = 0x00000001;
 
@@ -189,7 +176,7 @@ void MultiPrecisionArithmetic252ed::quickAMod() {
 }
 
 
-void MultiPrecisionArithmetic252ed::base16Mod(uint32_t* out, const uint32_t* a) {
+inline void MultiPrecisionArithmetic252ed::base16Mod(uint32_t* out, const uint32_t* a) {
 	prepareDoubleIn(a);
 
 	m = n + 1;
@@ -199,7 +186,7 @@ void MultiPrecisionArithmetic252ed::base16Mod(uint32_t* out, const uint32_t* a) 
 }
 
 
-void MultiPrecisionArithmetic252ed::base16Add(uint32_t* out, const uint32_t* a, const uint32_t* b) {
+inline void MultiPrecisionArithmetic252ed::base16Add(uint32_t* out, const uint32_t* a, const uint32_t* b) {
 	prepareIn(a, b);
 
 	carry = 0x00000000;
@@ -216,7 +203,7 @@ void MultiPrecisionArithmetic252ed::base16Add(uint32_t* out, const uint32_t* a, 
 }
 
 
-void MultiPrecisionArithmetic252ed::base16Mul(uint32_t* out, const uint32_t* a, const uint32_t* b) { // Might be able to optimize by using the Karatsuba method, or some other method. Maybe within the modulus operation as well.
+inline void MultiPrecisionArithmetic252ed::base16Mul(uint32_t* out, const uint32_t* a, const uint32_t* b) { // Might be able to optimize by using the Karatsuba method, or some other method. Maybe within the modulus operation as well.
 	prepareIn(a, b);
 
 	for(unsigned short i = ((n*2) - 1); i > (n - 1); i -= 1) {

--- a/src/include/multiprecision25519.h
+++ b/src/include/multiprecision25519.h
@@ -46,9 +46,6 @@ private:
 	void prepareOut(uint32_t*);
 	void prepareMulOut(uint32_t*); // Used after multiplication and the Barrett reduction.
 public:
-	MultiPrecisionArithmetic25519();
-	~MultiPrecisionArithmetic25519();
-
 	void base32_16(uint32_t*, const uint32_t*);
 
 	void base16Mod(uint32_t*, const uint32_t*);
@@ -60,17 +57,7 @@ public:
 };
 
 
-MultiPrecisionArithmetic25519::MultiPrecisionArithmetic25519() {
-
-}
-
-
-MultiPrecisionArithmetic25519::~MultiPrecisionArithmetic25519() {
-
-}
-
-
-void MultiPrecisionArithmetic25519::base32_16(uint32_t* out, const uint32_t* a) {
+inline void MultiPrecisionArithmetic25519::base32_16(uint32_t* out, const uint32_t* a) {
 	for(unsigned short i = 0; i < (n/2); i += 1) {
 		out[i*2] = a[i] >> 16;
 		out[(i*2) + 1] = a[i] & 0x0000ffff;
@@ -78,7 +65,7 @@ void MultiPrecisionArithmetic25519::base32_16(uint32_t* out, const uint32_t* a) 
 }
 
 
-void MultiPrecisionArithmetic25519::prepareModIn(const uint32_t* a) {
+inline void MultiPrecisionArithmetic25519::prepareModIn(const uint32_t* a) {
 	u[1] = 0x00000000;
 
 	for(unsigned short i = 0; i < n; i += 1) {
@@ -87,7 +74,7 @@ void MultiPrecisionArithmetic25519::prepareModIn(const uint32_t* a) {
 }
 
 
-void MultiPrecisionArithmetic25519::base16ModInternal() {
+inline void MultiPrecisionArithmetic25519::base16ModInternal() {
 // ---------- D1 ----------
 	carry = 0x00000000;
 
@@ -173,14 +160,14 @@ void MultiPrecisionArithmetic25519::base16ModInternal() {
 }
 
 
-void MultiPrecisionArithmetic25519::prepareOut(uint32_t* out) {
+inline void MultiPrecisionArithmetic25519::prepareOut(uint32_t* out) {
 	for(unsigned short i = 0; i < n; i += 1) {
 		out[i] = u[i + 2];
 	}
 }
 
 
-void MultiPrecisionArithmetic25519::prepareIn(const uint32_t* a, const uint32_t* b) {
+inline void MultiPrecisionArithmetic25519::prepareIn(const uint32_t* a, const uint32_t* b) {
 	u[1] = 0x00000000;
 	v[0] = 0x00000000;
 
@@ -191,7 +178,7 @@ void MultiPrecisionArithmetic25519::prepareIn(const uint32_t* a, const uint32_t*
 }
 
 
-void MultiPrecisionArithmetic25519::quickAMod() {
+inline void MultiPrecisionArithmetic25519::quickAMod() {
 	c = 0x00000000;
 	s = 0x00000001;
 
@@ -212,7 +199,7 @@ void MultiPrecisionArithmetic25519::quickAMod() {
 }
 
 
-void MultiPrecisionArithmetic25519::barrettReduce() {
+inline void MultiPrecisionArithmetic25519::barrettReduce() {
 // ---------- 1 ----------
 	for(unsigned short i = 0; i < (n + 1); i += 1) {
 		v[i] = u[i + 2]; // v is storing q1.
@@ -299,14 +286,14 @@ void MultiPrecisionArithmetic25519::barrettReduce() {
 }
 
 
-void MultiPrecisionArithmetic25519::prepareMulOut(uint32_t* out) {
+inline void MultiPrecisionArithmetic25519::prepareMulOut(uint32_t* out) {
 	for(unsigned short i = 0; i < n; i += 1) {
 		out[i] = u[i + 3];
 	}
 }
 
 
-void MultiPrecisionArithmetic25519::quickSMod() {
+inline void MultiPrecisionArithmetic25519::quickSMod() {
 	carry = 0x00000000;
 
 	for(unsigned short i = (n + 1); i > 1; i -= 1) {
@@ -319,7 +306,7 @@ void MultiPrecisionArithmetic25519::quickSMod() {
 }
 
 
-void MultiPrecisionArithmetic25519::base16Mod(uint32_t* out, const uint32_t* a) {
+inline void MultiPrecisionArithmetic25519::base16Mod(uint32_t* out, const uint32_t* a) {
 	prepareModIn(a);
 
 	m = 1;
@@ -329,7 +316,7 @@ void MultiPrecisionArithmetic25519::base16Mod(uint32_t* out, const uint32_t* a) 
 }
 
 
-void MultiPrecisionArithmetic25519::base16Add(uint32_t* out, const uint32_t* a, const uint32_t* b) {
+inline void MultiPrecisionArithmetic25519::base16Add(uint32_t* out, const uint32_t* a, const uint32_t* b) {
 	prepareIn(a, b);
 
 	carry = 0x00000000;
@@ -346,7 +333,7 @@ void MultiPrecisionArithmetic25519::base16Add(uint32_t* out, const uint32_t* a, 
 }
 
 
-void MultiPrecisionArithmetic25519::base16Mul(uint32_t* out, const uint32_t* a, const uint32_t* b) { // Might be able to optimize by using the Karatsuba method, or some other method. Maybe within the modulus operation as well.
+inline void MultiPrecisionArithmetic25519::base16Mul(uint32_t* out, const uint32_t* a, const uint32_t* b) { // Might be able to optimize by using the Karatsuba method, or some other method. Maybe within the modulus operation as well.
 	prepareIn(a, b);
 
 	for(unsigned short i = ((n*2) - 1); i > (n - 1); i -= 1) {
@@ -375,7 +362,7 @@ void MultiPrecisionArithmetic25519::base16Mul(uint32_t* out, const uint32_t* a, 
 }
 
 
-void MultiPrecisionArithmetic25519::base16Sub(uint32_t* out, const uint32_t* a, const uint32_t* b) {
+inline void MultiPrecisionArithmetic25519::base16Sub(uint32_t* out, const uint32_t* a, const uint32_t* b) {
 	prepareIn(a, b);
 
 	carry = 0x00000000;
@@ -394,7 +381,7 @@ void MultiPrecisionArithmetic25519::base16Sub(uint32_t* out, const uint32_t* a, 
 }
 
 
-void MultiPrecisionArithmetic25519::base16_32(uint32_t* out, const uint32_t* a) {
+inline void MultiPrecisionArithmetic25519::base16_32(uint32_t* out, const uint32_t* a) {
 	for(unsigned short i = 0; i < (n/2); i += 1) {
 		out[i] = (a[i*2] << 16) | a[(i*2) + 1];
 	}

--- a/src/include/poly1305.h
+++ b/src/include/poly1305.h
@@ -54,25 +54,12 @@ private:
 	void serializeLittleEndian(char*);
 	bool authenticateLittleEndian(char*);
 public:
-	Poly1305MAC();
-	~Poly1305MAC();
-
 	void createTag(char[TAG_BYTES], uint32_t[KEY_LENGTH], char*, unsigned long long);
 	bool authenticateTag(char[TAG_BYTES], uint32_t[KEY_LENGTH], char*, unsigned long long);
 };
 
 
-Poly1305MAC::Poly1305MAC() {
-
-}
-
-
-Poly1305MAC::~Poly1305MAC() {
-
-}
-
-
-void Poly1305MAC::clamp() {
+inline void Poly1305MAC::clamp() {
 	for(unsigned short i = 0; i < (INT_LENGTH - 1); i += 1) {
 		r[i] &= 0x0ffffffc;
 	}
@@ -81,7 +68,7 @@ void Poly1305MAC::clamp() {
 }
 
 
-void Poly1305MAC::prepareInt(uint32_t* key) {
+inline void Poly1305MAC::prepareInt(uint32_t* key) {
 	for(unsigned short i = 0; i < INT_LENGTH; i += 1) {
 		r[i] = key[(INT_LENGTH - 1) - i] << 24;
 		r[i] |= ((key[(INT_LENGTH - 1) - i] & 0x0000ff00) << 8);
@@ -109,7 +96,7 @@ void Poly1305MAC::prepareInt(uint32_t* key) {
 }
 
 
-void Poly1305MAC::initializeMAC(uint32_t* key, unsigned long long bytes) {
+inline void Poly1305MAC::initializeMAC(uint32_t* key, unsigned long long bytes) {
 	blockCounter = 0x00000000;
 	messageBlockCount = ((bytes - 1)/BLOCK_BYTES) + 1;
 	messageRemainder = bytes % BLOCK_BYTES;
@@ -118,7 +105,7 @@ void Poly1305MAC::initializeMAC(uint32_t* key, unsigned long long bytes) {
 }
 
 
-void Poly1305MAC::prepareBlockLittleEndian(char* message) {
+inline void Poly1305MAC::prepareBlockLittleEndian(char* message) {
 	blockIndexBytes = ((unsigned long)blockCounter)*BLOCK_BYTES;
 
 	for(unsigned short i = 0; i < DEPENDENT_BLOCK_LENGTH; i += 1) {
@@ -129,7 +116,7 @@ void Poly1305MAC::prepareBlockLittleEndian(char* message) {
 }
 
 
-void Poly1305MAC::prepareFinalBlockLittleEndian(char* message) {
+inline void Poly1305MAC::prepareFinalBlockLittleEndian(char* message) {
 	finalBlockLastWordIndex = DEPENDENT_BLOCK_LENGTH - ((messageRemainder - 1)/2);
 	blockIndexBytes = ((unsigned long)blockCounter)*BLOCK_BYTES;
 
@@ -151,13 +138,13 @@ void Poly1305MAC::prepareFinalBlockLittleEndian(char* message) {
 }
 
 
-void Poly1305MAC::tagSubProcess() {
+inline void Poly1305MAC::tagSubProcess() {
 	math.base16Add(acc, acc, block);
 	math.base16Mul(acc, acc, rMulti, (messageBlockCount > 2)); // This is not constant time, but the condition is derived from the length of the message, which is public.
 }
 
 
-void Poly1305MAC::incrementBlockCounter() {
+inline void Poly1305MAC::incrementBlockCounter() {
 	if(blockCounter == 0xffffffff) {
 		// Log an error here.
 	}
@@ -166,7 +153,7 @@ void Poly1305MAC::incrementBlockCounter() {
 }
 
 
-void Poly1305MAC::tagProcess(char* message) {
+inline void Poly1305MAC::tagProcess(char* message) {
 	for(unsigned long long i = 0; i < (messageBlockCount - 1); i += 1) {
 		prepareBlockLittleEndian(message);
 		tagSubProcess();
@@ -184,13 +171,13 @@ void Poly1305MAC::tagProcess(char* message) {
 }
 
 
-void Poly1305MAC::createAndAuthenticateProcess(uint32_t* key, char* message, unsigned long long bytes) {
+inline void Poly1305MAC::createAndAuthenticateProcess(uint32_t* key, char* message, unsigned long long bytes) {
 		initializeMAC(key, bytes);
 		tagProcess(message);
 }
 
 
-void Poly1305MAC::serializeLittleEndian(char* out) {
+inline void Poly1305MAC::serializeLittleEndian(char* out) {
 	for(unsigned short i = 0; i < DEPENDENT_BLOCK_LENGTH; i += 1) {
 		out[(i*2)] = acc[DEPENDENT_BLOCK_LENGTH - i] & BITMASK;
 		out[(i*2) + 1] = acc[DEPENDENT_BLOCK_LENGTH - i] >> 8;
@@ -198,7 +185,7 @@ void Poly1305MAC::serializeLittleEndian(char* out) {
 }
 
 
-bool Poly1305MAC::authenticateLittleEndian(char* tag) {
+inline bool Poly1305MAC::authenticateLittleEndian(char* tag) {
 	for(unsigned short i = 0; i < TAG_BYTES; i += 1) {
 		tempTag[i] = tag[i];
 	}
@@ -217,7 +204,7 @@ bool Poly1305MAC::authenticateLittleEndian(char* tag) {
 }
 
 
-void Poly1305MAC::createTag(char* out, uint32_t* key, char* message, unsigned long long bytes) {
+inline void Poly1305MAC::createTag(char* out, uint32_t* key, char* message, unsigned long long bytes) {
 	if(bytes > 0) {
 		createAndAuthenticateProcess(key, message, bytes);
 		serializeLittleEndian(out);
@@ -225,7 +212,7 @@ void Poly1305MAC::createTag(char* out, uint32_t* key, char* message, unsigned lo
 }
 
 
-bool Poly1305MAC::authenticateTag(char* tag, uint32_t* key, char* message, unsigned long long bytes) {
+inline bool Poly1305MAC::authenticateTag(char* tag, uint32_t* key, char* message, unsigned long long bytes) {
 	if(bytes > 0) {
 		createAndAuthenticateProcess(key, message, bytes);
 		return authenticateLittleEndian(tag);

--- a/src/include/rng.h
+++ b/src/include/rng.h
@@ -16,24 +16,11 @@ private:
 
 	void initializeSeed();
 public:
-	RNGen();
-	~RNGen();
-
 	void generateBytes(char*, unsigned short);
 };
 
 
-RNGen::RNGen() {
-
-}
-
-
-RNGen::~RNGen() {
-
-}
-
-
-void RNGen::initializeSeed() { // This should be handled as a bare minimum implementation of RNG. I am sure you can do better than me.
+inline void RNGen::initializeSeed() { // This should be handled as a bare minimum implementation of RNG. I am sure you can do better than me.
 	analogReadResolution(ANALOG_RESOLUTION);
 
 	seedVal = 0;
@@ -48,7 +35,7 @@ void RNGen::initializeSeed() { // This should be handled as a bare minimum imple
 }
 
 
-void RNGen::generateBytes(char* out, unsigned short bytes) {
+inline void RNGen::generateBytes(char* out, unsigned short bytes) {
 	initializeSeed();
 
 	for(unsigned short i = 0; i < bytes; i += 1) {


### PR DESCRIPTION
Hey, feel free to ignore/delete this pull request.

I just removed the empty constructors and destructors to allow the compiler to generate them (possible optimization), and made all functions inline so that the compiler will choose one definition when multiple exist. This allowed me to separate networking.h into a definition and implementation in glEEmail. I think it's important to do this for header-only libraries like LiteChaCha.